### PR TITLE
fix: resolve linting failures in the build pipeline

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{matrix.golangci-lint}}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,8 +18,8 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,4 +4,4 @@ linters:
   exclusions:
     rules:
       - linters: errcheck
-        text: "fmt\\.|file\\.Close"
+        text: "fmt\\.(Print|Fprintf|Fprintln)|file\\.Close"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  default: standard
+  exclusions:
+    rules:
+      - linters: errcheck
+        text: "fmt\\.|file\\.Close"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,5 +3,6 @@ linters:
   default: standard
   exclusions:
     rules:
-      - linters: errcheck
+      - linters: 
+        - errcheck
         text: "fmt\\.(Print|Fprintf|Fprintln)|file\\.Close"

--- a/hack/dev-tools.sh
+++ b/hack/dev-tools.sh
@@ -1,2 +1,1 @@
-#!/bin/bash
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.4

--- a/justfile
+++ b/justfile
@@ -38,7 +38,8 @@ set-control:
   echo "description: $DESCRIPTION" >> $CONTROL
 
 deb-pkg: build set-control
-  mkdir -pv $BIN 
+  mkdir -pv $BIN
+  mkdir -pv $PACKAGES
   mv bin/revisio $BIN
   dpkg-deb --build $ROOT $PACKAGES
   sha256sum $PACKAGES/$DEBPKG > $PACKAGES/$DEBSHA

--- a/pkg/createcmd/createcmd.go
+++ b/pkg/createcmd/createcmd.go
@@ -31,7 +31,7 @@ func New(rootConfig *rootcmd.RootConfig) *CreateConfig {
 		NoDefault: true,
 	})
 	if err != nil {
-		fmt.Fprintln(cfg.Stderr, rootcmd.AddFlagErr.Error())
+		fmt.Fprintln(cfg.Stderr, rootcmd.ErrAddFlag.Error())
 	}
 	_, err = cfg.Flags.AddFlag(ff.FlagConfig{
 		ShortName: 'v',
@@ -41,7 +41,7 @@ func New(rootConfig *rootcmd.RootConfig) *CreateConfig {
 		NoDefault: true,
 	})
 	if err != nil {
-		fmt.Fprintln(cfg.Stderr, rootcmd.AddFlagErr.Error())
+		fmt.Fprintln(cfg.Stderr, rootcmd.ErrAddFlag.Error())
 	}
 	cfg.Command = &ff.Command{
 		Name:      "create",

--- a/pkg/createcmd/createcmd.go
+++ b/pkg/createcmd/createcmd.go
@@ -56,9 +56,9 @@ func New(rootConfig *rootcmd.RootConfig) *CreateConfig {
 
 func (cfg *CreateConfig) Exec(ctx context.Context, args []string) error {
 	if cfg.Subject == "" {
-		return errors.New("Missing required flag: -k, --key")
+		return errors.New("missing required flag: -k, --key")
 	} else if cfg.Content == "" {
-		return errors.New("Missing required flag: -v, --value")
+		return errors.New("missing required flag: -v, --value")
 	}
 
 	if err := cfg.Client.Create(ctx, cfg.Subject, cfg.Content); err != nil {

--- a/pkg/readcmd/readcmd.go
+++ b/pkg/readcmd/readcmd.go
@@ -45,7 +45,7 @@ func New(rootConfig *rootcmd.RootConfig) *ReadConfig {
 func (cfg *ReadConfig) Exec(ctx context.Context, args []string) error {
 	subject := cfg.Flashcard.GetKey()
 	if *subject == "" {
-		return errors.New("Missing required flag: -k, --key")
+		return errors.New("missing required flag: -k, --key")
 	}
 
 	value, err := cfg.Client.ReadValue(ctx, *subject)

--- a/pkg/readcmd/readcmd.go
+++ b/pkg/readcmd/readcmd.go
@@ -29,7 +29,7 @@ func New(rootConfig *rootcmd.RootConfig) *ReadConfig {
 		NoDefault: true,
 	})
 	if err != nil {
-		fmt.Fprintln(cfg.Stderr, rootcmd.AddFlagErr.Error())
+		fmt.Fprintln(cfg.Stderr, rootcmd.ErrAddFlag.Error())
 	}
 	cfg.Command = &ff.Command{
 		Name:      "read",

--- a/pkg/rootcmd/rootcmd.go
+++ b/pkg/rootcmd/rootcmd.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	AddFlagErr = errors.New("unable to add flag")
+	ErrAddFlag = errors.New("unable to add flag")
 )
 
 type RootConfig struct {

--- a/pkg/rootcmd/rootcmd.go
+++ b/pkg/rootcmd/rootcmd.go
@@ -37,7 +37,7 @@ func New(stdout, stderr io.Writer) *RootConfig {
 		NoDefault: true,
 	})
 	if err != nil {
-		fmt.Fprintln(cfg.Stderr, AddFlagErr.Error())
+		fmt.Fprintln(cfg.Stderr, ErrAddFlag.Error())
 	}
 	cfg.Command = &ff.Command{
 		Name:      "revisio",


### PR DESCRIPTION
**Description**
<!-- A clear and concise description of the changes in this pull request. -->

Resolves linting failures in the build pipeline.

1. Updated [hack/dev-tools.sh](hack/dev-tools.sh) to pin v2.11.4 which is compatible with Go 1.26
2. Created golangci.yml and added exclusion rules for errcheck on fmt and file operations

**Related issues**
<!-- Closes #(issue number) -->
Closes #59

**Testing**
<!-- Describe the tests you ran to verify your changes:
1. ... -->
Confirmed it works [here](https://github.com/reuben-emmens/revisio/actions/runs/24479626174)  by running dpkg-deb wf on the feature branch.

**Checklist**
- [x] I have updated relevant documentation
- [x] New and existing unit tests pass with my changes
