### PR TITLE
docs: scaffold /docs folder for Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ go.work.sum
 
 # IDE
 .vscode/
+
+# Jekyll (docs/)
+docs/_site/
+docs/.jekyll-cache/
+docs/.jekyll-metadata
+docs/Gemfile.lock
+docs/vendor/

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 Welcome to 'revisio', the digital flashcard management tool. The goal of the project is to create a CLI application which can both import CSV data and accept key-value arguments to create flashcards.
 
 There are ideas for more extended functionality, but these should be weighted against the benefits of keeping the app lightweight with a consistent API for third-party extensibility.
+
+📖 Full documentation: https://reuben-emmens.github.io/revisio/

--- a/docs/.bundle/config
+++ b/docs/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+# Mirrors the plugins/versions GitHub Pages uses in production so `jekyll serve`
+# behaves the same locally as the pages-build-deployment workflow.
+gem "github-pages", group: :jekyll_plugins
+gem "webrick"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,9 +2,3 @@ title: revisio
 description: A lightweight CLI flashcard management tool
 theme: jekyll-theme-primer
 show_downloads: false
-
-# Only build the pages listed in the nav below plus index.md
-include:
-  - index.md
-  - getting-started.md
-  - commands.md

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,10 @@
+title: revisio
+description: A lightweight CLI flashcard management tool
+theme: jekyll-theme-primer
+show_downloads: false
+
+# Only build the pages listed in the nav below plus index.md
+include:
+  - index.md
+  - getting-started.md
+  - commands.md

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ revisio [FLAGS] <SUBCOMMAND> ...
 ## `revisio create`
 
 ```
-revisio create [FLAGS] <KEY> <VALUE>
+revisio [--verbose] create --key <KEY> --value <VALUE>
 ```
 
 Create a flashcard.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Command Reference
+---
+
+# Command Reference
+
+## `revisio`
+
+```
+revisio [FLAGS] <SUBCOMMAND> ...
+```
+
+| Flag        | Description         |
+| ----------- | -------------------- |
+| `--verbose` | Log verbose output   |
+
+## `revisio create`
+
+```
+revisio create [FLAGS] <KEY> <VALUE>
+```
+
+Create a flashcard.
+
+| Flag           | Description                |
+| -------------- | --------------------------- |
+| `-k, --key`    | The key of the flashcard    |
+| `-v, --value`  | The value of the flashcard  |
+
+## `revisio read`
+
+```
+revisio read [FLAGS] <KEY> <VALUE>
+```
+
+Read a flashcard.
+
+| Flag         | Description               |
+| ------------ | -------------------------- |
+| `-k, --key`  | The key of the flashcard   |
+
+## `revisio version`
+
+```
+revisio version
+```
+
+Print version information. Takes no flags beyond the global `--verbose`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,4 +43,4 @@ Check the installed version:
 revisio version
 ```
 
-See the [Command Reference](commands.md) for the full list of flags.
+See the [Command Reference](commands.html) for the full list of flags.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: Getting Started
+---
+
+# Getting Started
+
+## Installation
+
+Build from source with Go 1.22.3 or later:
+
+```sh
+git clone https://github.com/reuben-emmens/revisio.git
+cd revisio
+go build -o revisio ./cmd/revisio
+```
+
+Or install directly with `go install`:
+
+```sh
+go install github.com/reuben-emmens/revisio/cmd/revisio@latest
+```
+
+A `.deb` package is also available from the [releases page](https://github.com/reuben-emmens/revisio/releases).
+
+## Usage
+
+Create a flashcard:
+
+```sh
+revisio create --key "capital of France" --value "Paris"
+```
+
+Read a flashcard back:
+
+```sh
+revisio read --key "capital of France"
+```
+
+Check the installed version:
+
+```sh
+revisio version
+```
+
+See the [Command Reference](commands.md) for the full list of flags.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ title: Getting Started
 
 ## Installation
 
-Build from source with Go 1.22.3 or later:
+Build from source with Go 1.22 or later:
 
 ```sh
 git clone https://github.com/reuben-emmens/revisio.git

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: revisio
+---
+
+# revisio
+
+`revisio` is a digital flashcard management CLI. It lets you create flashcards
+from key/value pairs or import them in bulk from CSV, with a small, consistent
+API designed for third-party extensibility.
+
+- [Getting Started](getting-started.md) — install `revisio` and create your first flashcard.
+- [Command Reference](commands.md) — flags and usage for every subcommand.
+- [Source on GitHub](https://github.com/reuben-emmens/revisio) — issues, releases, and contribution guidelines.
+
+For a quick project overview, see the [repository README](https://github.com/reuben-emmens/revisio#readme).

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,28 @@ title: revisio
 from key/value pairs or import them in bulk from CSV, with a small, consistent
 API designed for third-party extensibility.
 
-- [Getting Started](getting-started.md) — install `revisio` and create your first flashcard.
-- [Command Reference](commands.md) — flags and usage for every subcommand.
+- [Getting Started](getting-started.html) — install `revisio` and create your first flashcard.
+- [Command Reference](commands.html) — flags and usage for every subcommand.
 - [Source on GitHub](https://github.com/reuben-emmens/revisio) — issues, releases, and contribution guidelines.
 
 For a quick project overview, see the [repository README](https://github.com/reuben-emmens/revisio#readme).
+
+To render this site locally:
+
+```sh
+# 1. Install Ruby and native build tools
+sudo apt-get install -y ruby-full build-essential zlib1g-dev
+
+# 2. Install Bundler
+gem install bundler
+
+# 3. From the docs/ folder, install gems into a local vendor path
+cd docs
+bundle config set --local path 'vendor/bundle'
+bundle install
+
+# 4. Serve the site with live reload
+bundle exec jekyll serve
+```
+
+Open [http://localhost:4000](http://localhost:4000) to view the site. Editing any file under `docs/` triggers an automatic rebuild


### PR DESCRIPTION
**Description**
<!-- A clear and concise description of the changes in this pull request. -->

This pull request introduces a bare bones docs folder.

Documentation site setup:

* Added Jekyll configuration (`_config.yml`), a `Gemfile` for dependencies, and a Bundler config to enable local documentation builds in the `docs/` directory. [[1]](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556R1-R4) [[2]](diffhunk://#diff-8917ad0c60eeb8cbc1928f85c76ec02b466b61e4b349cdff0a9f4646fb7822c1R1-R6) [[3]](diffhunk://#diff-d95f36d93d8ebced2306bdf2d69e8661a163730a70f3a65ae9e10191a3c95690R1-R2)
* Created a landing page (`index.md`) with project overview, navigation links, and instructions for building and serving the documentation locally.

User documentation:

* Added a "Getting Started" guide (`getting-started.md`) with installation instructions (source, Go install, and `.deb` package), and sample usage for creating, reading, and checking the version of flashcards.
* Added a "Command Reference" (`commands.md`) detailing available subcommands, flags, and usage examples for the CLI.

Project README update:

* Updated the main `README.md` to include a link to the full documentation site.

**Related issues**
<!-- Closes #(issue number) -->

Closing #68

**Testing**
<!-- Describe the tests you ran to verify your changes:
1. ... -->


**Checklist**
- [x] I have updated relevant documentation
- [x] New and existing unit tests pass with my changes
